### PR TITLE
Increase text length limit to 250 characters

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -3,14 +3,27 @@ using System.ComponentModel.DataAnnotations;
 namespace RazorPagesTestSample.Data
 {
     #region snippet1
+    /// <summary>
+    /// Represents a message with an ID and text content.
+    /// </summary>
     public class Message
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the message.
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text content of the message.
+        /// </summary>
+        /// <remarks>
+        /// The text content is required and has a maximum length of 250 characters.
+        /// </remarks>
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion
 }
+


### PR DESCRIPTION
This pull request includes documentation improvements and a minor validation update to the `Message` class in the `RazorPagesTestSample` project.

Documentation improvements:

* Added XML comments to the `Message` class and its `Id` and `Text` properties to provide a summary and additional details.

Validation update:

* Increased the maximum length of the `Text` property from 200 to 250 characters.… 250 characters. Resolves the character limit issue